### PR TITLE
Prevent an infinite loop with duplicated tweakers

### DIFF
--- a/src/main/java/net/minecraft/launchwrapper/Launch.java
+++ b/src/main/java/net/minecraft/launchwrapper/Launch.java
@@ -83,6 +83,8 @@ public class Launch {
                     // Safety check - don't reprocess something we've already visited
                     if (allTweakerNames.contains(tweakName)) {
                         LogWrapper.log(Level.WARNING, "Tweak class name %s has already been visited -- skipping", tweakName);
+                        // remove the tweaker from the stack otherwise it will create an infinite loop
+                        it.remove();
                         continue;
                     } else {
                         allTweakerNames.add(tweakName);


### PR DESCRIPTION
The sanity check for duplicated tweakers works and does correctly skip instancing the tweaker, however because the tweak is not removed from the tweak class list it creates an infinite loop.

This can be easily tested by just specifying the same tweak class more than once on the command line.
