### PR TITLE
Fixed gamedir change being injected too low

### DIFF
--- a/src/main/java/net/minecraft/launchwrapper/injector/VanillaTweakInjector.java
+++ b/src/main/java/net/minecraft/launchwrapper/injector/VanillaTweakInjector.java
@@ -2,7 +2,6 @@ package net.minecraft.launchwrapper.injector;
 
 import net.minecraft.launchwrapper.IClassTransformer;
 import net.minecraft.launchwrapper.Launch;
-import net.minecraft.launchwrapper.VanillaTweaker;
 import org.lwjgl.opengl.Display;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
@@ -18,7 +17,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
-import java.util.ListIterator;
 
 import static org.objectweb.asm.Opcodes.*;
 
@@ -70,14 +68,8 @@ public class VanillaTweakInjector implements IClassTransformer {
         // Store the result in the workDir variable.
         injectedMethod.visitFieldInsn(PUTSTATIC, "net/minecraft/client/Minecraft", workDirNode.name, "Ljava/io/File;");
 
-        // Find the injection point and insert our code
-        final ListIterator<AbstractInsnNode> iterator = mainMethod.instructions.iterator();
-        while (iterator.hasNext()) {
-            final AbstractInsnNode insn = iterator.next();
-            if (insn.getOpcode() == RETURN) {
-                mainMethod.instructions.insertBefore(insn, injectedMethod.instructions);
-            }
-        }
+        // Insert our code
+        mainMethod.instructions.insert(injectedMethod.instructions);
 
         final ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
         classNode.accept(writer);


### PR DESCRIPTION
I wanted to move all my modded setups to the new launcher, so i made a profile for 1.5.2 with forge and chose a different runtime folder. I started the game and all files appeared in the default folder. I taught that this was a fault of the mods, so i tried it with an clean 1.5.2 profile. Same error here.

There are 2 files that do appear in the new profile directory, and that are the debug.stitched_items.png and debug.stitched_blocks.png files.

I enabled the launchwrapper class save option (-Dlegacy.debugClassLoadingSave=true) and decompiled the net.minecraft.client.Minecraft class from that. 
In there, i saw the problem. The game dir is injected at the end of the main method. After the game is actually started and loaded.
I moved this injection up to the top of the main method. This fixed the problem

If you want the proof, ask me for screenshots or test it yourself

I have not tested yet if this problem exists for Indev and Alpha too, if it does, i will update this PR
