### PR TITLE
Fix typo in VanillaTweakInjector

### DIFF
--- a/src/main/java/net/minecraft/launchwrapper/injector/VanillaTweakInjector.java
+++ b/src/main/java/net/minecraft/launchwrapper/injector/VanillaTweakInjector.java
@@ -77,7 +77,7 @@ public class VanillaTweakInjector implements IClassTransformer {
 
     public static File inject() {
         // Speed up imageloading
-        System.out.println("Turning of ImageIO disk-caching");
+        System.out.println("Turning off ImageIO disk-caching");
         ImageIO.setUseCache(false);
 
         loadIconsOnFrames();


### PR DESCRIPTION
On line 80, a message is printed to the console: "Turning of ImageIO disk-caching". There is a typo: Turning _of_. This PR simply changes it to "Turning off ImageIO disk-caching". Cheers to dsuser97 for spotting that.
