### PR TITLE
Fix for project jigsaw ClassLoader change

### DIFF
--- a/src/main/java/net/minecraft/launchwrapper/Launch.java
+++ b/src/main/java/net/minecraft/launchwrapper/Launch.java
@@ -46,10 +46,10 @@ public class Launch {
     private URL[] getURLs() {
         String cp = System.getProperty("java.class.path");
         String[] elements = cp.split(File.pathSeparator);
-        URL[] urls = new URL[elements.length];
         if (elements.length == 0) {
             elements = new String[] { "" };
         }
+        URL[] urls = new URL[elements.length];
         for (int i = 0; i < elements.length; i++) {
             try {
                 URL url = new File(elements[i]).toURI().toURL();


### PR DESCRIPTION
In project jigsaw the appclassloader is no longer a URLClassLoader becus URLClassLoader is backed by an URLClassPath and in project jigsaw is it posebule to run without a classpath using modulepath instead 

> The specification does not mandate the concrete types of either of these class loaders, nor their precise delegation relationship.

and 
if you want to try jigsaw ea builds are [here](https://jdk9.java.net/download/)
here is a stacktrace to show the problem

```
Exception in thread "main" java.lang.ClassCastException: jdk.internal.misc.ClassLoaders$AppClassLoader (in module: java.base) cannot be cast to java.net.URLClassLoader (in module: java.base)
    at net.minecraft.launchwrapper.Launch.<init>(Launch.java:34)
    at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
```
