### PR TITLE
Fixed order of insertion for VanillaTweakInjector patch

### DIFF
--- a/src/main/java/net/minecraft/launchwrapper/injector/VanillaTweakInjector.java
+++ b/src/main/java/net/minecraft/launchwrapper/injector/VanillaTweakInjector.java
@@ -6,6 +6,7 @@ import org.lwjgl.opengl.Display;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Label;
+import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.*;
 
@@ -59,16 +60,17 @@ public class VanillaTweakInjector implements IClassTransformer {
         }
 
         // Prepare our injection code
-        final MethodNode injectedMethod = new MethodNode();
-        final Label label = new Label();
-        injectedMethod.visitLabel(label);
-        injectedMethod.visitLineNumber(9001, label); // Linenumber which shows up in the stacktrace
+        final InsnList injectedCode = new InsnList();
+        final LabelNode label = new LabelNode();
+        injectedCode.add(label);
+        // Linenumber which shows up in the stacktrace
+        injectedCode.add(new LineNumberNode(9001, label));
         // Call the method below
-        injectedMethod.visitMethodInsn(INVOKESTATIC, "net/minecraft/launchwrapper/injector/VanillaTweakInjector", "inject", "()Ljava/io/File;");
+        injectedCode.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "net/minecraft/launchwrapper/injector/VanillaTweakInjector", "inject", "()Ljava/io/File;", false));
         // Store the result in the workDir variable.
-        injectedMethod.visitFieldInsn(PUTSTATIC, "net/minecraft/client/Minecraft", workDirNode.name, "Ljava/io/File;");
+        injectedCode.add(new FieldInsnNode(Opcodes.PUTSTATIC, "net/minecraft/client/Minecraft", workDirNode.name, "Ljava/io/File;"));
 
-        mainMethod.instructions.insert(injectedMethod.instructions);
+        mainMethod.instructions.insert(injectedCode);
 
         final ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
         classNode.accept(writer);


### PR DESCRIPTION
There's a bug in the VanillaTweakInjector where the hook to set the minecraftDir variable is being done at the end of main, **after** startMainThread is called.  This results in an intermittent issue where the game directory isn't always set properly in time.  I confirmed this in both the vanilla launcher and MultiMC by simply opening an instance of Minecraft Beta 1.7.3 repeatedly and checking where it was trying to get my world saves from, and it would vary between the proper instance folder and the root .minecraft folder.

To verify the difference you can compare disassembled versions of net.mincraft.client.Minecraft using the standard debug parms:  -Dlegacy.debugClassLoading=true -Dlegacy.debugClassLoadingFiner=true -Dlegacy.debugClassLoadingSave=true

Note that a consequence of using modern builds of Launchwrapper with old versions of the game though is that you have to add log4j and update ASM to 5.0.3 in the version json.

