### PR TITLE
private -> public

### DIFF
--- a/src/main/java/net/minecraft/launchwrapper/Launch.java
+++ b/src/main/java/net/minecraft/launchwrapper/Launch.java
@@ -37,7 +37,7 @@ public class Launch {
         Thread.currentThread().setContextClassLoader(classLoader);
     }
 
-    private void launch(String[] args) {
+    public void launch(String[] args) {
         final OptionParser parser = new OptionParser();
         parser.allowsUnrecognizedOptions();
 


### PR DESCRIPTION
I need to call the launch(String[] args) method in Launch.class (What I'm doing fails when using main()) but I can't because its set to private.

I would just package the jar with a modified launchwrapper, but I don't what to because of #1