### PR TITLE
MCL-19983 & WEB-1429 Fixed legacy skin loading & server authentication.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ repositories {
 
 group = 'net.minecraft'
 archivesBaseName = 'launchwrapper'
-version = '1.12'
+version = '1.13'
 sourceCompatibility = 1.6
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     compile 'org.lwjgl.lwjgl:lwjgl:2.9.1'
     compile 'org.apache.logging.log4j:log4j-core:2.0-beta9'
     compile 'org.apache.logging.log4j:log4j-api:2.0-beta9'
+    compile 'com.mojang:authlib:2.3.31'
 }
 
 task sourcesJar(type: Jar) {

--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,9 @@ dependencies {
     compile 'net.sf.jopt-simple:jopt-simple:4.5'
     compile 'org.ow2.asm:asm-debug-all:5.0.3'
     compile 'org.lwjgl.lwjgl:lwjgl:2.9.1'
-    compile 'org.apache.logging.log4j:log4j-core:2.0-beta9'
-    compile 'org.apache.logging.log4j:log4j-api:2.0-beta9'
+    compile 'org.apache.logging.log4j:log4j-core:2.16.0'
+    compile 'org.apache.logging.log4j:log4j-api:2.16.0'
+    compile 'org.apache.logging.log4j:log4j-slf4j18-impl:2.16.0'
     compile 'com.mojang:authlib:2.3.31'
 }
 

--- a/src/main/java/net/minecraft/launchwrapper/Launch.java
+++ b/src/main/java/net/minecraft/launchwrapper/Launch.java
@@ -15,8 +15,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.net.URL;
 
 import org.apache.logging.log4j.Level;
+
+import net.minecraft.launchwrapper.protocol.LegacyProtocolURLStreamHandlerFactory;
 
 public class Launch {
     private static final String DEFAULT_TWEAK = "net.minecraft.launchwrapper.VanillaTweaker";
@@ -31,6 +34,7 @@ public class Launch {
     public static LaunchClassLoader classLoader;
 
     private Launch() {
+        URL.setURLStreamHandlerFactory(new LegacyProtocolURLStreamHandlerFactory());
         final URLClassLoader ucl = (URLClassLoader) getClass().getClassLoader();
         classLoader = new LaunchClassLoader(ucl.getURLs());
         blackboard = new HashMap<String,Object>();

--- a/src/main/java/net/minecraft/launchwrapper/protocol/CapeURLConnection.java
+++ b/src/main/java/net/minecraft/launchwrapper/protocol/CapeURLConnection.java
@@ -14,6 +14,13 @@ import com.mojang.authlib.Agent;
 import com.mojang.authlib.yggdrasil.YggdrasilAuthenticationService;
 
 public class CapeURLConnection extends HttpURLConnection {
+
+    public final static String[] OLD_CAPE_ADDRESSES = new String[] {
+            "http://www.minecraft.net/cloak/get.jsp?user=", // Introduced Beta 1.0 (when capes were added)
+            "http://s3.amazonaws.com/MinecraftCloaks/",     // Introduced Beta 1.2
+            "http://skins.minecraft.net/MinecraftCloaks/"   // Introduced Release 1.3.1
+    };
+
     public CapeURLConnection(URL url) {
         super(url);
     }
@@ -30,15 +37,22 @@ public class CapeURLConnection extends HttpURLConnection {
     InputStream inputStream = null;
     int responseCode = 200;
 
+    private String getUsernameFromURL() {
+        String username = this.url.toString();
+
+        // We get the username from the skin by replacing the url up to the username with whitespace.
+        for (String oldCapeAddress : OLD_CAPE_ADDRESSES) {
+            username = username.replace(oldCapeAddress, "");
+        }
+        /// ... and dropping the .png.
+        username = username.replace(".png", "");
+
+        return username;
+    }
+
     @Override
     public void connect() throws IOException {
-        String url = this.url.toString();
-        String username = url.contains("/MinecraftCloaks/")
-                ? url.substring(url.indexOf("/MinecraftCloaks/"))
-                .replace("/MinecraftCloaks/", "")
-                .replace(".png", "")
-                : url.substring(url.indexOf("/cloak/get.jsp?user="))
-                .replace("/cloak/get.jsp?user=", "");
+        String username = getUsernameFromURL();
 
         try {
             MinecraftProfileTexture cape = getUserCape(username);

--- a/src/main/java/net/minecraft/launchwrapper/protocol/CapeURLConnection.java
+++ b/src/main/java/net/minecraft/launchwrapper/protocol/CapeURLConnection.java
@@ -1,0 +1,84 @@
+package net.minecraft.launchwrapper.protocol;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Map;
+import java.net.Proxy;
+
+import com.mojang.authlib.minecraft.MinecraftProfileTexture;
+import com.mojang.authlib.ProfileLookupCallback;
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.Agent;
+import com.mojang.authlib.yggdrasil.YggdrasilAuthenticationService;
+
+public class CapeURLConnection extends HttpURLConnection {
+    public CapeURLConnection(URL url) {
+        super(url);
+    }
+
+    @Override
+    public void disconnect() {
+    }
+
+    @Override
+    public boolean usingProxy() {
+        return false;
+    }
+
+    InputStream inputStream = null;
+    int responseCode = 200;
+
+    @Override
+    public void connect() throws IOException {
+        String url = this.url.toString();
+        String username = url.contains("/MinecraftCloaks/")
+                ? url.substring(url.indexOf("/MinecraftCloaks/"))
+                .replace("/MinecraftCloaks/", "")
+                .replace(".png", "")
+                : url.substring(url.indexOf("/cloak/get.jsp?user="))
+                .replace("/cloak/get.jsp?user=", "");
+
+        try {
+            MinecraftProfileTexture cape = getUserCape(username);
+            inputStream = new URL(cape.getUrl()).openConnection().getInputStream();
+        } catch (Exception ex) {
+            responseCode = 404;
+        }
+    }
+
+    YggdrasilAuthenticationService authenticationService = new YggdrasilAuthenticationService(Proxy.NO_PROXY, (String)null);
+    GameProfile gameProfile = null;
+
+    private MinecraftProfileTexture getUserCape(String username) {
+        authenticationService.createProfileRepository().findProfilesByNames(new String[] { username }, Agent.MINECRAFT, new ProfileLookupCallback() {
+            public void onProfileLookupSucceeded(GameProfile paramGameProfile) {
+                gameProfile = paramGameProfile;
+            }
+            public void onProfileLookupFailed(GameProfile paramGameProfile, Exception paramException) {
+            }
+        });
+
+        if (gameProfile == null)
+            return null;
+
+        gameProfile = authenticationService.createMinecraftSessionService().fillProfileProperties(gameProfile, true);
+
+        Map<MinecraftProfileTexture.Type, MinecraftProfileTexture> textures = authenticationService.createMinecraftSessionService().getTextures(gameProfile, true);
+        if (textures.containsKey(MinecraftProfileTexture.Type.CAPE))
+            return textures.get(MinecraftProfileTexture.Type.CAPE);
+
+        return null;
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        return inputStream;
+    }
+
+    @Override
+    public int getResponseCode() {
+        return responseCode;
+    }
+}

--- a/src/main/java/net/minecraft/launchwrapper/protocol/JoinServerURLConnection.java
+++ b/src/main/java/net/minecraft/launchwrapper/protocol/JoinServerURLConnection.java
@@ -1,0 +1,98 @@
+package net.minecraft.launchwrapper.protocol;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.Proxy;
+import java.util.Map;
+import java.util.HashMap;
+
+import com.mojang.authlib.ProfileLookupCallback;
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.Agent;
+import com.mojang.authlib.exceptions.AuthenticationException;
+import com.mojang.authlib.yggdrasil.YggdrasilAuthenticationService;
+
+public class JoinServerURLConnection extends HttpURLConnection {
+    public JoinServerURLConnection(URL url) {
+        super(url);
+    }
+
+    @Override
+    public void disconnect() {
+
+    }
+
+    @Override
+    public boolean usingProxy() {
+        return false;
+    }
+
+    private String response = "bad login";
+
+    @Override
+    public void connect() throws IOException {
+
+    }
+
+    YggdrasilAuthenticationService authenticationService = new YggdrasilAuthenticationService(Proxy.NO_PROXY, (String)null);
+
+    GameProfile gameProfile = null;
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        // Pull params from the URL query.
+        String[] params = this.url.getQuery().split("&");
+        Map<String, String> queryMap = new HashMap<String, String>();
+
+        for (String param : params) {
+            String name = param.split("=")[0];
+            String value = param.split("=")[1];
+            queryMap.put(name, value);
+        }
+
+        String username = queryMap.get("user");
+        // sessionId is token:<accessToken>:<playerId>. We want the access token.
+        String accessToken = queryMap.get("sessionId").split(":")[1];
+        String serverId = queryMap.get("serverId");
+
+        // Lookup the game profile by username.
+        authenticationService.createProfileRepository().findProfilesByNames(new String[] { username }, Agent.MINECRAFT, new ProfileLookupCallback() {
+            public void onProfileLookupSucceeded(GameProfile paramGameProfile) {
+                gameProfile = paramGameProfile;
+            }
+            public void onProfileLookupFailed(GameProfile paramGameProfile, Exception paramException) {
+            }
+        });
+
+        if (gameProfile == null)
+            return null;
+
+        // Send the join request.
+        try {
+            authenticationService.createMinecraftSessionService().joinServer(
+                    gameProfile,
+                    accessToken,
+                    serverId
+            );
+
+            response = "ok";
+        } catch (AuthenticationException ex) {
+            // response defaults to "bad login"
+        }
+
+        return new ByteArrayInputStream(response.getBytes());
+    }
+
+    @Override
+    public int getResponseCode() {
+        return 200;
+    }
+
+    @Override
+    public String getResponseMessage() {
+        return "ok";
+    }
+}

--- a/src/main/java/net/minecraft/launchwrapper/protocol/LegacyProtocolURLStreamHandler.java
+++ b/src/main/java/net/minecraft/launchwrapper/protocol/LegacyProtocolURLStreamHandler.java
@@ -1,7 +1,5 @@
 package net.minecraft.launchwrapper.protocol;
 
-import sun.net.www.protocol.http.HttpURLConnection;
-
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLConnection;
@@ -22,6 +20,11 @@ public class LegacyProtocolURLStreamHandler extends URLStreamHandler {
                 return new CapeURLConnection(url);
         }
 
-        return new HttpURLConnection(url, null);
+        try {
+            return defaultHttpConnectionClass.getConstructor(URL.class, Proxy.class).newInstance(url, null);
+        } catch (Exception e) {
+            // If the constructor isn't found, you can log that out. It's not expected.
+            return null;
+        }
     }
 }

--- a/src/main/java/net/minecraft/launchwrapper/protocol/LegacyProtocolURLStreamHandler.java
+++ b/src/main/java/net/minecraft/launchwrapper/protocol/LegacyProtocolURLStreamHandler.java
@@ -2,10 +2,17 @@ package net.minecraft.launchwrapper.protocol;
 
 import java.io.IOException;
 import java.net.URL;
+import java.net.Proxy;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
 
 public class LegacyProtocolURLStreamHandler extends URLStreamHandler {
+    private final Class<? extends URLConnection> defaultHttpConnectionClass;
+
+    public LegacyProtocolURLStreamHandler(Class<? extends URLConnection> _defaultHttpConnectionClass) {
+        defaultHttpConnectionClass = _defaultHttpConnectionClass;
+    }
+
     @Override
     protected URLConnection openConnection(URL url) throws IOException {
         // Skins are pulled from the new endpoint and converted to the legacy format as required.
@@ -20,8 +27,13 @@ public class LegacyProtocolURLStreamHandler extends URLStreamHandler {
                 return new CapeURLConnection(url);
         }
 
+        // Server authentication is done over a newer endpoint.
+        if (url.toString().startsWith("http://www.minecraft.net/game/joinserver.jsp")) {
+            return new JoinServerURLConnection(url);
+        }
+
         try {
-            return defaultHttpConnectionClass.getConstructor(URL.class, Proxy.class).newInstance(url, null);
+            return defaultHttpConnectionClass.getConstructor(URL.class, Proxy.class).newInstance(url, Proxy.NO_PROXY);
         } catch (Exception e) {
             // If the constructor isn't found, you can log that out. It's not expected.
             return null;

--- a/src/main/java/net/minecraft/launchwrapper/protocol/LegacyProtocolURLStreamHandler.java
+++ b/src/main/java/net/minecraft/launchwrapper/protocol/LegacyProtocolURLStreamHandler.java
@@ -1,0 +1,22 @@
+package net.minecraft.launchwrapper.protocol;
+
+import sun.net.www.protocol.http.HttpURLConnection;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+
+public class LegacyProtocolURLStreamHandler extends URLStreamHandler {
+    @Override
+    protected URLConnection openConnection(URL url) throws IOException {
+        // Skins are pulled from the new endpoint and converted to the legacy format as required.
+        if (url.toString().startsWith("http://s3.amazonaws.com/MinecraftSkins/") || url.toString().contains("/skin/"))
+            return new SkinURLConnection(url);
+        // Capes are pulled from the new endpoint, no conversion is required.
+        else if (url.toString().startsWith("http://s3.amazonaws.com//MinecraftCloaks//") || url.toString().contains("/cloak/get.jsp?user="))
+            return new CapeURLConnection(url);
+
+        return new HttpURLConnection(url, null);
+    }
+}

--- a/src/main/java/net/minecraft/launchwrapper/protocol/LegacyProtocolURLStreamHandler.java
+++ b/src/main/java/net/minecraft/launchwrapper/protocol/LegacyProtocolURLStreamHandler.java
@@ -11,11 +11,16 @@ public class LegacyProtocolURLStreamHandler extends URLStreamHandler {
     @Override
     protected URLConnection openConnection(URL url) throws IOException {
         // Skins are pulled from the new endpoint and converted to the legacy format as required.
-        if (url.toString().startsWith("http://s3.amazonaws.com/MinecraftSkins/") || url.toString().contains("/skin/"))
-            return new SkinURLConnection(url);
+        for (String oldSkinAddress : SkinURLConnection.OLD_SKIN_ADDRESSES) {
+            if (url.toString().startsWith(oldSkinAddress))
+                return new SkinURLConnection(url);
+        }
+
         // Capes are pulled from the new endpoint, no conversion is required.
-        else if (url.toString().startsWith("http://s3.amazonaws.com//MinecraftCloaks//") || url.toString().contains("/cloak/get.jsp?user="))
-            return new CapeURLConnection(url);
+        for (String oldCapeAddress : CapeURLConnection.OLD_CAPE_ADDRESSES) {
+            if (url.toString().startsWith(oldCapeAddress))
+                return new CapeURLConnection(url);
+        }
 
         return new HttpURLConnection(url, null);
     }

--- a/src/main/java/net/minecraft/launchwrapper/protocol/LegacyProtocolURLStreamHandlerFactory.java
+++ b/src/main/java/net/minecraft/launchwrapper/protocol/LegacyProtocolURLStreamHandlerFactory.java
@@ -1,0 +1,15 @@
+package net.minecraft.launchwrapper.protocol;
+
+import java.net.URLStreamHandler;
+import java.net.URLStreamHandlerFactory;
+
+public class LegacyProtocolURLStreamHandlerFactory implements URLStreamHandlerFactory {
+    @Override
+    public URLStreamHandler createURLStreamHandler(String protocol) {
+        if ("http".equals(protocol)) {
+            return new LegacyProtocolURLStreamHandler();
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/net/minecraft/launchwrapper/protocol/LegacyProtocolURLStreamHandlerFactory.java
+++ b/src/main/java/net/minecraft/launchwrapper/protocol/LegacyProtocolURLStreamHandlerFactory.java
@@ -1,5 +1,7 @@
 package net.minecraft.launchwrapper.protocol;
 
+import java.net.URL;
+import java.net.URLConnection;
 import java.net.URLStreamHandler;
 import java.net.URLStreamHandlerFactory;
 

--- a/src/main/java/net/minecraft/launchwrapper/protocol/LegacyProtocolURLStreamHandlerFactory.java
+++ b/src/main/java/net/minecraft/launchwrapper/protocol/LegacyProtocolURLStreamHandlerFactory.java
@@ -4,10 +4,23 @@ import java.net.URLStreamHandler;
 import java.net.URLStreamHandlerFactory;
 
 public class LegacyProtocolURLStreamHandlerFactory implements URLStreamHandlerFactory {
+    private final Class<? extends URLConnection> defaultHttpConnectionClass;
+
+    public LegacyProtocolURLStreamHandlerFactory() {
+        try {
+            URL foo = new URL("http://example.com");
+            // Doesn't actually establish a connection
+            defaultHttpConnectionClass = foo.openConnection().getClass();
+        } catch (Exception e) {
+            // this should never happen as the URL is hardcoded, shouldn't be invalid.
+            throw new RuntimeException(e);
+        }
+    }
+
     @Override
     public URLStreamHandler createURLStreamHandler(String protocol) {
         if ("http".equals(protocol)) {
-            return new LegacyProtocolURLStreamHandler();
+            return new LegacyProtocolURLStreamHandler(defaultHttpConnectionClass);
         }
 
         return null;

--- a/src/main/java/net/minecraft/launchwrapper/protocol/SkinURLConnection.java
+++ b/src/main/java/net/minecraft/launchwrapper/protocol/SkinURLConnection.java
@@ -21,6 +21,13 @@ import com.mojang.authlib.Agent;
 import com.mojang.authlib.yggdrasil.YggdrasilAuthenticationService;
 
 public class SkinURLConnection extends HttpURLConnection {
+
+    public final static String[] OLD_SKIN_ADDRESSES = new String[] {
+            "http://www.minecraft.net/skin/",               // Introduced Classic 0.0.18a (when skins were added)
+            "http://s3.amazonaws.com/MinecraftSkins/",      // Introduced Beta 1.2
+            "http://skins.minecraft.net/MinecraftSkins/"    // Introduced Release 1.3.1
+    };
+
     public SkinURLConnection(URL url) {
         super(url);
     }
@@ -37,16 +44,22 @@ public class SkinURLConnection extends HttpURLConnection {
     InputStream inputStream = null;
     int responseCode = 200;
 
+    private String getUsernameFromURL() {
+        String username = this.url.toString();
+
+        // We get the username from the skin by replacing the url up to the username with whitespace.
+        for (String oldSkinAddress : OLD_SKIN_ADDRESSES) {
+            username = username.replace(oldSkinAddress, "");
+        }
+        /// ... and dropping the .png.
+        username = username.replace(".png", "");
+
+        return username;
+    }
+
     @Override
     public void connect() throws IOException {
-        String url = this.url.toString();
-        String username = (url.contains("/MinecraftSkins/")
-                ? url.substring(url.indexOf("/MinecraftSkins/"))
-                .replace("/MinecraftSkins/", "")
-                .replace(".png", "")
-                : url.substring(url.indexOf("/skin/")))
-                .replace("/skin/", "")
-                .replace(".png", "");
+        String username = getUsernameFromURL();
 
         try {
             MinecraftProfileTexture skin = getUserSkin(username);

--- a/src/main/java/net/minecraft/launchwrapper/protocol/SkinURLConnection.java
+++ b/src/main/java/net/minecraft/launchwrapper/protocol/SkinURLConnection.java
@@ -104,6 +104,12 @@ public class SkinURLConnection extends HttpURLConnection {
         AlphaComposite alpha = AlphaComposite.getInstance(AlphaComposite.SRC_OVER);
         graphics.setComposite(alpha);
 
+        if (tall) {
+            // Flatten second layers.
+            movePart = skin.getSubimage(0, 32, 56, 16);
+            graphics.drawImage(movePart, 0, 16, null);
+        }
+
         if (slim) {
             // Convert alex to steve.
 
@@ -114,38 +120,6 @@ public class SkinURLConnection extends HttpURLConnection {
             graphics.drawImage(movePart, 50, 16, null);
             movePart = skin.getSubimage(53, 20, 2, 12);
             graphics.drawImage(movePart, 54, 20, null);
-
-            if (tall) {
-                // Stretch right sleeve.
-                movePart = skin.getSubimage(45, 32, 9, 16);
-                graphics.drawImage(movePart, 46, 32, null);
-                movePart = skin.getSubimage(49, 32, 2, 4);
-                graphics.drawImage(movePart, 50, 32, null);
-                movePart = skin.getSubimage(53, 36, 2, 12);
-                graphics.drawImage(movePart, 54, 36, null);
-
-                // Stretch left arm.
-                movePart = skin.getSubimage(37, 48, 9, 16);
-                graphics.drawImage(movePart, 38, 48, null);
-                movePart = skin.getSubimage(41, 48, 2, 4);
-                graphics.drawImage(movePart, 42, 32, null);
-                movePart = skin.getSubimage(45, 52, 2, 12);
-                graphics.drawImage(movePart, 46, 36, null);
-
-                // Stretch left sleeve.
-                movePart = skin.getSubimage(53, 48, 9, 16);
-                graphics.drawImage(movePart, 54, 48, null);
-                movePart = skin.getSubimage(57, 48, 2, 4);
-                graphics.drawImage(movePart, 58, 32, null);
-                movePart = skin.getSubimage(61, 52, 2, 12);
-                graphics.drawImage(movePart, 62, 36, null);
-            }
-        }
-
-        if (tall) {
-            // Flatten second layers.
-            movePart = skin.getSubimage(0, 32, 56, 16);
-            graphics.drawImage(movePart, 0, 16, null);
         }
 
         graphics.dispose();

--- a/src/main/java/net/minecraft/launchwrapper/protocol/SkinURLConnection.java
+++ b/src/main/java/net/minecraft/launchwrapper/protocol/SkinURLConnection.java
@@ -1,0 +1,157 @@
+package net.minecraft.launchwrapper.protocol;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import javax.imageio.ImageIO;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.awt.image.BufferedImage;
+import java.awt.*;
+import java.util.Map;
+import java.net.Proxy;
+
+import com.mojang.authlib.minecraft.MinecraftProfileTexture;
+import com.mojang.authlib.ProfileLookupCallback;
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.Agent;
+import com.mojang.authlib.yggdrasil.YggdrasilAuthenticationService;
+
+public class SkinURLConnection extends HttpURLConnection {
+    public SkinURLConnection(URL url) {
+        super(url);
+    }
+
+    @Override
+    public void disconnect() {
+    }
+
+    @Override
+    public boolean usingProxy() {
+        return false;
+    }
+
+    InputStream inputStream = null;
+    int responseCode = 200;
+
+    @Override
+    public void connect() throws IOException {
+        String url = this.url.toString();
+        String username = (url.contains("/MinecraftSkins/")
+                ? url.substring(url.indexOf("/MinecraftSkins/"))
+                .replace("/MinecraftSkins/", "")
+                .replace(".png", "")
+                : url.substring(url.indexOf("/skin/")))
+                .replace("/skin/", "")
+                .replace(".png", "");
+
+        try {
+            MinecraftProfileTexture skin = getUserSkin(username);
+            boolean slim = "slim".equals(skin.getMetadata("model"));
+            inputStream = convertModernSkin(new URL(skin.getUrl()), slim);
+        } catch (Exception ex) {
+            responseCode = 404;
+        }
+    }
+
+    GameProfile gameProfile = null;
+    YggdrasilAuthenticationService authenticationService = new YggdrasilAuthenticationService(Proxy.NO_PROXY, (String)null);
+
+    private MinecraftProfileTexture getUserSkin(String username) {
+        authenticationService.createProfileRepository().findProfilesByNames(new String[] { username }, Agent.MINECRAFT, new ProfileLookupCallback() {
+            public void onProfileLookupSucceeded(GameProfile paramGameProfile) {
+                gameProfile = paramGameProfile;
+            }
+            public void onProfileLookupFailed(GameProfile paramGameProfile, Exception paramException) {
+            }
+        });
+
+        if (gameProfile == null)
+            return null;
+
+        gameProfile = authenticationService.createMinecraftSessionService().fillProfileProperties(gameProfile, true);
+
+        Map<MinecraftProfileTexture.Type, MinecraftProfileTexture> textures = authenticationService.createMinecraftSessionService().getTextures(gameProfile, true);
+
+        if (textures.containsKey(MinecraftProfileTexture.Type.SKIN))
+            return textures.get(MinecraftProfileTexture.Type.SKIN);
+
+        return null;
+    }
+
+    public static InputStream convertModernSkin(URL skinUrl, boolean slim) throws IOException {
+        InputStream inputStream = skinUrl.openStream();
+        BufferedImage skin = ImageIO.read(inputStream);
+        boolean tall = skin.getHeight() > 32;
+        BufferedImage movePart = null;
+        Graphics2D graphics = skin.createGraphics();
+        AlphaComposite alpha = AlphaComposite.getInstance(AlphaComposite.SRC_OVER);
+        graphics.setComposite(alpha);
+
+        if (slim) {
+            // Convert alex to steve.
+
+            // Stretch right arm.
+            movePart = skin.getSubimage(45, 16, 9, 16);
+            graphics.drawImage(movePart, 46, 16, null);
+            movePart = skin.getSubimage(49, 16, 2, 4);
+            graphics.drawImage(movePart, 50, 16, null);
+            movePart = skin.getSubimage(53, 20, 2, 12);
+            graphics.drawImage(movePart, 54, 20, null);
+
+            if (tall) {
+                // Stretch right sleeve.
+                movePart = skin.getSubimage(45, 32, 9, 16);
+                graphics.drawImage(movePart, 46, 32, null);
+                movePart = skin.getSubimage(49, 32, 2, 4);
+                graphics.drawImage(movePart, 50, 32, null);
+                movePart = skin.getSubimage(53, 36, 2, 12);
+                graphics.drawImage(movePart, 54, 36, null);
+
+                // Stretch left arm.
+                movePart = skin.getSubimage(37, 48, 9, 16);
+                graphics.drawImage(movePart, 38, 48, null);
+                movePart = skin.getSubimage(41, 48, 2, 4);
+                graphics.drawImage(movePart, 42, 32, null);
+                movePart = skin.getSubimage(45, 52, 2, 12);
+                graphics.drawImage(movePart, 46, 36, null);
+
+                // Stretch left sleeve.
+                movePart = skin.getSubimage(53, 48, 9, 16);
+                graphics.drawImage(movePart, 54, 48, null);
+                movePart = skin.getSubimage(57, 48, 2, 4);
+                graphics.drawImage(movePart, 58, 32, null);
+                movePart = skin.getSubimage(61, 52, 2, 12);
+                graphics.drawImage(movePart, 62, 36, null);
+            }
+        }
+
+        if (tall) {
+            // Flatten second layers.
+            movePart = skin.getSubimage(0, 32, 56, 16);
+            graphics.drawImage(movePart, 0, 16, null);
+        }
+
+        graphics.dispose();
+
+        // Crop
+        BufferedImage croppedSkin = skin.getSubimage(0, 0, 64, 32);
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        ImageIO.write(croppedSkin, "png", os);
+        byte[] bytes = os.toByteArray();
+        return new ByteArrayInputStream(bytes);
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        return inputStream;
+    }
+
+    @Override
+    public int getResponseCode() {
+        return responseCode;
+    }
+}


### PR DESCRIPTION
# Summary of Changes

## MCL-19983 Skin Fix
Per [MCL-19983](https://bugs.mojang.com/browse/MCL-19983), this pull requests fixes skins in legacy versions of Minecraft by registering a custom HTTP protocol, to essentially override requests to the URL where skins used to be back then. 
The protocol uses authlib to fetch skins just like modern versions of Minecraft do.

I believe this is the only way to fix this skin issue, as skins used to be hosted at s3.amazonaws.com, it is unlikely it can be resolved server-side.

## WEB-1429 Server Login Fix
As described in [WEB-1429](https://bugs.mojang.com/browse/WEB-1429), it is currently impossible to join secured (`online-mode=true`) legacy servers. The game used to authenticate via minecraft.net, but this has since been moved. I have solved this using a custom HTTP handler which intercepts the server login request before it is performed, and uses Authlib to perform this request instead.

I believe this is the only suitable solution for this bug, as legacy minecraft versions are written to use HTTP rather than HTTPS, and include the access token in the URL, so handling this on the server side is insecure, and it should be done on the client side instead.

# Additional Information

Since legacy Minecraft does not support the slim skin model, slim skins will be appropriately stretched out for the classic model. The screenshot below is an example of a slim skin.

![image](https://user-images.githubusercontent.com/11706994/139843746-6948771a-7106-4e70-9b9b-7754e7959797.png)

I have also updated log4j, due to the infamous vulnerability, you can see #34 for more on that.

# Deployment
Were this pull request accepted, to deploy the fix would require updating launcher manifest JSON files for legacy versions. The json files would need launchwrapper bumped to the latest version, and would need some additional dependencies for authlib, the same ones modern minecraft has.
The new dependencies are:

- org.apache.logging.log4j:log4j-api:2.16.0
- org.apache.logging.log4j:log4j-core:2.16.0
- org.apache.logging.log4j:log4j-slf4j18-impl:2.16.0
- com.mojang:authlib:2.3.31
- com.google.code.gson:gson:2.8.0
- org.apache.commons:commons-lang3:3.5
- com.google.guava:guava:21.0
- commons-io:commons-io:2.5
- commons-codec:commons-codec:1.10

# Testing Guidance
## Skins
- Launch a legacy version using the new launchwrapper with any custom skin.
- Load into any world and after a moment your custom skin should appear.
## Server Login
- Start a legacy server with an online-mode fix applied (you can find one [here](https://github.com/craftycodie/OnlineModeFix), there are many others.)
- Join the server.