### PR TITLE
[CVE-2021-44228]: Update Log4J to resolve security issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,9 @@ dependencies {
     compile 'net.sf.jopt-simple:jopt-simple:4.5'
     compile 'org.ow2.asm:asm-debug-all:5.0.3'
     compile 'org.lwjgl.lwjgl:lwjgl:2.9.1'
-    compile 'org.apache.logging.log4j:log4j-core:2.0-beta9'
-    compile 'org.apache.logging.log4j:log4j-api:2.0-beta9'
+    compile 'org.apache.logging.log4j:log4j-core:2.15.0'
+    compile 'org.apache.logging.log4j:log4j-api:2.15.0'
+    compile 'org.apache.logging.log4j:log4j-slf4j18-impl:2.15.0'
 }
 
 task sourcesJar(type: Jar) {

--- a/build.gradle
+++ b/build.gradle
@@ -18,9 +18,9 @@ dependencies {
     compile 'net.sf.jopt-simple:jopt-simple:4.5'
     compile 'org.ow2.asm:asm-debug-all:5.0.3'
     compile 'org.lwjgl.lwjgl:lwjgl:2.9.1'
-    compile 'org.apache.logging.log4j:log4j-core:2.15.0'
-    compile 'org.apache.logging.log4j:log4j-api:2.15.0'
-    compile 'org.apache.logging.log4j:log4j-slf4j18-impl:2.15.0'
+    compile 'org.apache.logging.log4j:log4j-core:2.16.0'
+    compile 'org.apache.logging.log4j:log4j-api:2.16.0'
+    compile 'org.apache.logging.log4j:log4j-slf4j18-impl:2.16.0'
 }
 
 task sourcesJar(type: Jar) {


### PR DESCRIPTION
Some downstream projects may be vulnerable if they don't explicitly define what log4j version to use themselves, best to update log4j for any downstream projects that may still use LegacyLauncher.